### PR TITLE
Improve modifier search experience

### DIFF
--- a/src/components/modifiers/DesiredModifiers.jsx
+++ b/src/components/modifiers/DesiredModifiers.jsx
@@ -332,6 +332,7 @@ function DesiredModifiers({ modData, onGenerateIdols }) {
             <ModifierSearch
               modData={modData}
               onAddModifier={handleAddModifier}
+              modifierList={desiredModifiers}
               initialState={searchHistoryRef.current}
               onSearchUpdate={handleSearchUpdate}
               searchContext="autogen"

--- a/src/components/modifiers/ModifierSearch.jsx
+++ b/src/components/modifiers/ModifierSearch.jsx
@@ -745,7 +745,15 @@ function ModifierSearch({
                       }
                       )
                     </h4>
-                    <div className="max-h-36 overflow-y-auto bg-slate-700 rounded-md ring-1 ring-slate-600 custom-scrollbar">
+                    <div
+                      className={`min-h-14 overflow-y-auto bg-slate-700 rounded-md ring-1 ring-slate-600 custom-scrollbar resize-y ${
+                        filteredModifiers.prefixes.filter(
+                          (p) => p.Name === name
+                        ).length === 1
+                          ? "h-auto"
+                          : "h-36"
+                      }`}
+                    >
                       {filteredModifiers.prefixes
                         .filter((prefix) => prefix.Name === name)
                         .map((prefix, index) => (
@@ -787,7 +795,16 @@ function ModifierSearch({
                       }
                       )
                     </h4>
-                    <div className="max-h-36 overflow-y-auto bg-slate-700 rounded-md ring-1 ring-slate-600 custom-scrollbar">
+                    <div
+                      className={`min-h-14 overflow-y-auto bg-slate-700 rounded-md ring-1 ring-slate-600 custom-scrollbar resize-y ${
+                        filteredModifiers.suffixes.filter(
+                          (suffix) =>
+                            suffix.Name === name || suffix.Name === `of ${name}`
+                        ).length === 1
+                          ? "h-auto"
+                          : "h-36"
+                      }`}
+                    >
                       {filteredModifiers.suffixes
                         .filter(
                           (suffix) =>
@@ -839,7 +856,11 @@ function ModifierSearch({
               <h3 className="font-medium text-blue-400 mb-2 text-sm px-1">
                 Prefixes ({filteredModifiers.prefixes.length})
               </h3>
-              <div className="max-h-40 overflow-y-auto bg-slate-700 rounded-md ring-1 ring-slate-600 custom-scrollbar">
+              <div
+                className={`min-h-14 overflow-y-auto bg-slate-700 rounded-md ring-1 ring-slate-600 custom-scrollbar resize-y ${
+                  filteredModifiers.prefixes.length === 1 ? "h-auto" : "h-40"
+                }`}
+              >
                 {filteredModifiers.prefixes.map((prefix, index) => (
                   <div
                     key={`prefix-${prefix.id}-${index}`}
@@ -867,7 +888,11 @@ function ModifierSearch({
               <h3 className="font-medium text-green-400 mb-2 text-sm px-1">
                 Suffixes ({filteredModifiers.suffixes.length})
               </h3>
-              <div className="max-h-40 overflow-y-auto bg-slate-700 rounded-md ring-1 ring-slate-600 custom-scrollbar">
+              <div
+                className={`min-h-14 overflow-y-auto bg-slate-700 rounded-md ring-1 ring-slate-600 custom-scrollbar resize-y ${
+                  filteredModifiers.suffixes.length === 1 ? "h-auto" : "h-40"
+                }`}
+              >
                 {filteredModifiers.suffixes.map((suffix, index) => (
                   <div
                     key={`suffix-${suffix.id}-${index}`}

--- a/src/components/modifiers/ModifierSearch.jsx
+++ b/src/components/modifiers/ModifierSearch.jsx
@@ -759,7 +759,7 @@ function ModifierSearch({
                         .map((prefix, index) => (
                           <div
                             key={`prefix-${prefix.id}-${index}`}
-                            className="p-3 hover:bg-slate-600 border-b border-slate-600 text-sm cursor-pointer transition-colors"
+                            className="p-3 hover:bg-slate-600 active:bg-slate-600/50 border-b border-slate-600 text-sm cursor-pointer transition-colors select-none"
                             onClick={() => onAddModifier(prefix, "prefix")}
                           >
                             <div className="font-medium text-white">
@@ -813,7 +813,7 @@ function ModifierSearch({
                         .map((suffix, index) => (
                           <div
                             key={`suffix-${suffix.id}-${index}`}
-                            className="p-3 hover:bg-slate-600 border-b border-slate-600 text-sm cursor-pointer transition-colors"
+                            className="p-3 hover:bg-slate-600 active:bg-slate-600/50 border-b border-slate-600 text-sm cursor-pointer transition-colors select-none"
                             onClick={() => onAddModifier(suffix, "suffix")}
                           >
                             <div className="font-medium text-white">
@@ -864,7 +864,7 @@ function ModifierSearch({
                 {filteredModifiers.prefixes.map((prefix, index) => (
                   <div
                     key={`prefix-${prefix.id}-${index}`}
-                    className="p-2.5 hover:bg-slate-600 border-b border-slate-600 text-sm cursor-pointer transition-colors"
+                    className="p-2.5 hover:bg-slate-600 active:bg-slate-600/50 border-b border-slate-600 text-sm cursor-pointer transition-colors select-none"
                     onClick={() => onAddModifier(prefix, "prefix")}
                   >
                     <div className="font-medium text-white">{prefix.Name}</div>
@@ -896,7 +896,7 @@ function ModifierSearch({
                 {filteredModifiers.suffixes.map((suffix, index) => (
                   <div
                     key={`suffix-${suffix.id}-${index}`}
-                    className="p-2.5 hover:bg-slate-600 border-b border-slate-600 text-sm cursor-pointer transition-colors"
+                    className="p-2.5 hover:bg-slate-600 active:bg-slate-600/50 border-b border-slate-600 text-sm cursor-pointer transition-colors select-none"
                     onClick={() => onAddModifier(suffix, "suffix")}
                   >
                     <div className="font-medium text-white">{suffix.Name}</div>

--- a/src/components/modifiers/ModifierSearch.jsx
+++ b/src/components/modifiers/ModifierSearch.jsx
@@ -764,6 +764,20 @@ function ModifierSearch({
                           >
                             <div className="font-medium text-white">
                               {prefix.Name}
+                              {modifierList &&
+                                modifierList.find(
+                                  (m) => m.id === prefix.id
+                                ) && (
+                                  <span className="text-yellow-400 font-bold ml-2">
+                                    (
+                                    {
+                                      modifierList.find(
+                                        (m) => m.id === prefix.id
+                                      ).count
+                                    }
+                                    ×)
+                                  </span>
+                                )}
                             </div>
                             <div className="text-slate-300 text-xs mt-1">
                               {prefix.Mod}
@@ -818,6 +832,20 @@ function ModifierSearch({
                           >
                             <div className="font-medium text-white">
                               {suffix.Name}
+                              {modifierList &&
+                                modifierList.find(
+                                  (m) => m.id === suffix.id
+                                ) && (
+                                  <span className="text-yellow-400 font-bold ml-2">
+                                    (
+                                    {
+                                      modifierList.find(
+                                        (m) => m.id === suffix.id
+                                      ).count
+                                    }
+                                    ×)
+                                  </span>
+                                )}
                             </div>
                             <div className="text-slate-300 text-xs mt-1">
                               {suffix.Mod}
@@ -867,7 +895,17 @@ function ModifierSearch({
                     className="p-2.5 hover:bg-slate-600 active:bg-slate-600/50 border-b border-slate-600 text-sm cursor-pointer transition-colors select-none"
                     onClick={() => onAddModifier(prefix, "prefix")}
                   >
-                    <div className="font-medium text-white">{prefix.Name}</div>
+                    <div className="font-medium text-white">
+                      {prefix.Name}
+                      {modifierList &&
+                        modifierList.find((m) => m.id === prefix.id) && (
+                          <span className="text-yellow-400 font-bold ml-2">
+                            (
+                            {modifierList.find((m) => m.id === prefix.id).count}
+                            ×)
+                          </span>
+                        )}
+                    </div>
                     <div className="text-slate-300 text-xs mt-1">
                       {prefix.Mod}
                     </div>
@@ -899,7 +937,17 @@ function ModifierSearch({
                     className="p-2.5 hover:bg-slate-600 active:bg-slate-600/50 border-b border-slate-600 text-sm cursor-pointer transition-colors select-none"
                     onClick={() => onAddModifier(suffix, "suffix")}
                   >
-                    <div className="font-medium text-white">{suffix.Name}</div>
+                    <div className="font-medium text-white">
+                      {suffix.Name}
+                      {modifierList &&
+                        modifierList.find((m) => m.id === suffix.id) && (
+                          <span className="text-yellow-400 font-bold ml-2">
+                            (
+                            {modifierList.find((m) => m.id === suffix.id).count}
+                            ×)
+                          </span>
+                        )}
+                    </div>
                     <div className="text-slate-300 text-xs mt-1">
                       {suffix.Mod}
                     </div>


### PR DESCRIPTION
This PR updates the `ModifierSearch` component to do the following:
- Allow resizing the search results list box, to view more than 2 prefixes/suffixes at a time in a search
- Add visual feedback for clicking to add a modifier
- Prevent selecting text in a modifier search result (annoying when you click more than once)
- Show the count of a modifier in the search results, for convenience & additional feedback on-click (Auto-Generate)


Each commit should be fairly descriptive & work independently, so if you like one of my ideas but not all, it will be easy to accommodate. No worries either way. Thanks for creating this awesome tool!